### PR TITLE
Migrate to the new Sonatype OSSRH infrastructure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,8 @@ config {
 nexusPublishing {
     repositories {
         sonatype {
+            nexusUrl = uri('https://s01.oss.sonatype.org/service/local/')
+            snapshotRepositoryUrl = uri('https://s01.oss.sonatype.org/content/repositories/snapshots/')
             username = ossrhUsername
             password = ossrhPassword
         }


### PR DESCRIPTION
New OSSRH infrastructure is much faster than the old one. The access to the old one has been revoked anyway.


