### PR TITLE
chore(deps): bump Micronaut to 5.0.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,8 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishVersion = 2.1.3
 
-micronautVersion = 5.0.0
-micronautGradlePluginVersion = 5.0.0
+micronautVersion = 5.0.6
+micronautGradlePluginVersion = 5.0.2
 
 segmentLibrariesVersion = 2.1.1
 


### PR DESCRIPTION
Bumps Micronaut to 5.0.6 and the Micronaut Gradle plugin to 5.0.2. Part of the MN 5.0.6 OSS release train (ships as micronaut-segment 3.0.0 GA).